### PR TITLE
Fixed serializer injection

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,19 +1,13 @@
 parameters:
   cl_slack.api_client.class: CL\Slack\Transport\ApiClient
   cl_slack.payload_registry.class: CL\Slack\Util\PayloadRegistry
-  cl_slack.payload_serializer.class: CL\Slack\Util\PayloadSerializer
 
 services:
   cl_slack.api_client:
     class: %cl_slack.api_client.class%
     arguments:
       - %cl_slack.api_token%
-      - @cl_slack.payload_serializer
+      - @jms_serializer.serializer
 
   cl_slack.payload_registry:
     class: %cl_slack.payload_registry.class%
-
-  cl_slack.payload_serializer:
-    class: %cl_slack.payload_serializer.class%
-    arguments:
-      - @jms_serializer.serializer


### PR DESCRIPTION
I've fixed an error with injecting the serializer.

First error was that there is no `CL\Slack\Util\PayloadSerializer` but there is `CL\Slack\Serializer\PayloadSerializer`.
The second error was that `CL\Slack\Serializer\PayloadSerializer` is abstract so can't be instantiated and the `ApiClient` expects an instance of `SerializerInterface` from `JMS` so why not inject the jms_serializer. This makes the bundle actually work ;)