### PR TITLE
Don't allow updates to version prior to 0.14.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": ">=5.4",
-    "cleentfaar/slack": "~0.14",
+    "cleentfaar/slack": "0.14.1",
     "symfony/framework-bundle": "~2.2"
   },
   "require-dev": {


### PR DESCRIPTION
Bundle need to stay in 0.14.1 due to depency on CL/Slack/Util/PayloadFactory that doesn't exist on version prior to 0.14.1