### PR TITLE
Allow minor version to increase.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": ">=5.4",
-    "cleentfaar/slack": "~0.15.3",
+    "cleentfaar/slack": "^0.15.3",
     "symfony/framework-bundle": "~2.2"
   },
   "require-dev": {


### PR DESCRIPTION
Allow the version `cleentfaar/slack` to increase to the latest tag (smaller than <1.0.0).
This allows for new features to be used.

To test this in an existing project you can add:

```json
{
  "cleentfaar/slack-bundle": "^0.15.4",
  "cleentfaar/slack": "0.17.1 as 0.15.4"
}
```