### PR TITLE
Quoting scalars

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -7,18 +7,18 @@ parameters:
 
 services:
   cl_slack.api_client:
-    class: %cl_slack.api_client.class%
+    class: "%cl_slack.api_client.class%"
     arguments:
-      - %cl_slack.api_token%
+      - "%cl_slack.api_token%"
 
   cl_slack.mock_api_client:
-    class: %cl_slack.mock_api_client.class%
+    class: "%cl_slack.mock_api_client.class%"
 
   cl_slack.model_serializer:
-    class: %cl_slack.model_serializer.class%
+    class: "%cl_slack.model_serializer.class%"
 
   cl_slack.payload_serializer:
-    class: %cl_slack.payload_serializer.class%
+    class: "%cl_slack.payload_serializer.class%"
 
   cl_slack.payload_response_serializer:
-    class: %cl_slack.payload_response_serializer.class%
+    class: "%cl_slack.payload_response_serializer.class%"


### PR DESCRIPTION
Fix deprecations:

Not quoting the scalar "%cl_slack.api_client.class%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0